### PR TITLE
마이페이지- 좋아요/북마크 개수 클릭 시 진입되는 postList페이지

### DIFF
--- a/src/pages/mypage/postlist/index.tsx
+++ b/src/pages/mypage/postlist/index.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { useState, useEffect } from "react";
+import AuthorIntro from "@components/AuthorIntro";
+import ContentWrapper from "@components/ContentWrapper";
+import ContentRow from "@components/ContentRow";
+import myBookmarkArticle from "@pages/tmp/myBookmarkArticle";
+import { Article } from "../../../types/article";
+import * as s from "./styles";
+import { tmpImageURL } from "@pages/tmp/tmpImageURL";
+import authors from "@pages/tmp/authors";
+
+// 추후 userName은 props로 받아오는것으로 수정되어야 함
+interface textSetInterface {
+  bookmarkPost: string;
+  likePost: string;
+  userName: Array<string>;
+}
+
+export default function PostList() {
+  const [array, setArray] = useState<Article[]>([]);
+
+  //api로 받아오는 로그인 유저 정보,페이지 정보(더미데이터)
+  const userId = "박상준";
+  const isBookmark = true;
+
+  useEffect(() => {
+    getArticleList();
+  }, []);
+
+  const textSet: textSetInterface = {
+    bookmarkPost: " 북마크한 글",
+    likePost: " 좋아요를 누른 글",
+    userName: ["내가", "님이"],
+  };
+
+  //임시 데이터 불러옴
+  const getArticleList = () => {
+    setArray([...array, ...myBookmarkArticle]);
+  };
+
+  return (
+    <div>
+      <s.Wrapper>
+        <s.TopContainer>
+          <AuthorIntro
+            authorName={authors[0].authorName}
+            intro={authors[0].intro}
+            imageURL={tmpImageURL}
+          />
+        </s.TopContainer>
+        <s.AllPostContainer>
+          <s.AllPost>
+            {(userId === authors[0].authorName
+              ? textSet.userName[0]
+              : authors[0].authorName + textSet.userName[1]) +
+              (isBookmark ? textSet.bookmarkPost : textSet.likePost)}
+          </s.AllPost>
+          <s.CountPost>{myBookmarkArticle.length}개</s.CountPost>
+        </s.AllPostContainer>
+        <s.BottomContainer>
+          <ContentWrapper
+            contentName={
+              (userId === authors[0].authorName
+                ? textSet.userName[0]
+                : authors[0].authorName + textSet.userName[1]) +
+              (isBookmark ? textSet.bookmarkPost : textSet.likePost)
+            }
+          >
+            {myBookmarkArticle.length
+              ? array.map((e: Article, index: number) => (
+                  <ContentRow
+                    index={index + 1}
+                    key={index + 1}
+                    contentInfo={{
+                      ...e,
+                    }}
+                  />
+                ))
+              : "게시글이 없습니다."}
+            <button onClick={() => getArticleList()}>더 불러오기</button>
+          </ContentWrapper>
+        </s.BottomContainer>
+      </s.Wrapper>
+    </div>
+  );
+}

--- a/src/pages/mypage/postlist/styles.ts
+++ b/src/pages/mypage/postlist/styles.ts
@@ -1,0 +1,38 @@
+import styled from "@emotion/styled";
+import theme from "@styles/Theme";
+
+const defaultVal = {
+  defaultPadding: "0 5vw",
+};
+
+export const Wrapper = styled.div`
+  background-color: ${theme.COLORS.CONTAINER_WHITE};
+  padding: ${defaultVal.defaultPadding};
+`;
+
+export const TopContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: ${theme.COLORS.CONTAINER_WHITE};
+`;
+
+export const AllPostContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: left;
+  font-size: ${theme.FONT_SIZE.SUB_TITLE_SIZE};
+  background: ${theme.COLORS.CONTAINER_WHITE};
+  padding-bottom: 2vh;
+  border-bottom: 1px solid ${theme.COLORS.BRIGHT_ORANGE};
+`;
+export const AllPost = styled.div`
+  padding-right: 8px;
+`;
+export const CountPost = styled.div`
+  color: ${theme.COLORS.BRIGHT_ORANGE};
+`;
+export const BottomContainer = styled.div`
+  min-height: 90vh;
+`;

--- a/src/pages/tmp/authors.ts
+++ b/src/pages/tmp/authors.ts
@@ -5,22 +5,22 @@ const authors: IAuthorProps[] = [
   {
     authorName: "박상준",
     intro: "꿈은 없고, 계속 놀고만 싶습니다.",
-    imageURL: tmpImageURL
+    imageURL: tmpImageURL,
   },
   {
     authorName: "박성준",
     intro: "꿈은 없고, 계속 안 놀고 싶습니다.",
-    imageURL: tmpImageURL
+    imageURL: tmpImageURL,
   },
   {
     authorName: "박송준",
     intro: "꿈은 있고, 계속 놀고만 싶습니다.",
-    imageURL: tmpImageURL
+    imageURL: tmpImageURL,
   },
   {
     authorName: "박승준",
     intro: "꿈은 있고, 계속 안 놀고 싶습니다.",
-    imageURL: tmpImageURL
+    imageURL: tmpImageURL,
   },
 ];
 


### PR DESCRIPTION

## 작업 내용
> 마이페이지- 좋아요/북마크 개수 클릭 시 진입되는 postList페이지 제작을 하였습니다.

<br/>

## 변동 내용
> 좋아요/북마크 개수 클릭 시 진입되는 postList페이지 제작
임시로 구현했습니다(타인페이지, 마이페이지 진입 시 달라지는 문구 변화, 좋아요/북마크 클릭 시 달라지는 문구변화)
(영상에서 업로드 될 때마다 게시물이 늘어나는 issue는 매번 useEffect가 실행되어서이므로 나중에 실제 데이터를 받아올 때 수정될 코드라는 점 참고해주세요)

<br/>

## 자료 첨부
> 

https://user-images.githubusercontent.com/98648819/215321630-993bcbc0-6179-451a-b6d4-1d445a64a93a.mp4

https://user-images.githubusercontent.com/98648819/215321642-f4877e62-c153-4999-b573-bbec3faaf674.mp4


<br/>

## 중점으로 리뷰받고 싶은 내용
> 

<br/>

## 참고자료
> 참고한 자료를 첨부해주세요. 
